### PR TITLE
Some small improvements

### DIFF
--- a/custom_components/scene_presets/__init__.py
+++ b/custom_components/scene_presets/__init__.py
@@ -67,6 +67,9 @@ async def async_setup(hass, config):
 
 
     async def start_dynamic_scene(call):
+        # always stop any existing actions first
+        await stop_dynamic_scenes_for_targets(call)
+
         preset_id = call.data.get(ATTR_SCENE_PRESET_ID)
         targets = call.data.get(ATTR_TARGETS)
         interval = call.data.get(ATTR_INTERVAL)


### PR DESCRIPTION
Hi, first of all great work on this, think its will be valuable to a lot of people.

May I suggest a few improvements in this PR:

- Stop running an existing dynamic scene when you start one for given entities
- The original Hue color schemas define both xy and colortemperature for non-colorlights. As the presets only contain the xy colors I've added a small converter to convert the xy color to the nearest color temperature for these cases.
- Use a short transition when starting a dynamic scene and use the configured transition time only for the subsequent loops
- Ignore a broightness of "0" as well as "None"
- Stop running a dynamic scene as soon as the lights power off --> although this needs a bit more work to clean up the remaining task.