### PR TITLE
Fix resolve group hidden members

### DIFF
--- a/custom_components/scene_presets/util.py
+++ b/custom_components/scene_presets/util.py
@@ -1,5 +1,4 @@
-from homeassistant.helpers import device_registry, entity_registry
-
+from homeassistant.helpers import entity_registry, device_registry
 
 def ensure_list(data):
     if isinstance(data, list):
@@ -23,15 +22,9 @@ def resolve_targets(hass, entity_ids, device_ids, area_ids):
         device_entries = device_registry.async_entries_for_area(device_reg, area_id)
 
         for device_entry in device_entries:
-            registry_entries = entity_registry.async_entries_for_device(
-                entity_reg, device_entry.id
-            )
+            registry_entries = entity_registry.async_entries_for_device(entity_reg, device_entry.id)
 
-            resolved_entity_ids.extend(
-                entry.entity_id
-                for entry in registry_entries
-                if entry.domain == "light" or entry.domain == "group"
-            )
+            resolved_entity_ids.extend(entry.entity_id for entry in registry_entries if entry.domain == 'light' or entry.domain == 'group')
 
     # Then we take all entity IDs, try to figure out if they're lights, groups or groups posing as lights and resolve them down to plain lights
     for entity_id in entity_ids:
@@ -39,28 +32,22 @@ def resolve_targets(hass, entity_ids, device_ids, area_ids):
 
     # Finally, Devices can be resolved last, because they should never provide groups and thus should only ever contain plain light entities
     for device_id in device_ids:
-        registry_entries = entity_registry.async_entries_for_device(
-            entity_reg, device_id
-        )
+        registry_entries = entity_registry.async_entries_for_device(entity_reg, device_id)
 
-        resolved_entity_ids.extend(
-            entry.entity_id for entry in registry_entries if entry.domain == "light"
-        )
+        resolved_entity_ids.extend(entry.entity_id for entry in registry_entries if entry.domain == 'light')
 
     # Deduplicate entity_id list
     resolved_entity_ids = list(set(resolved_entity_ids))
 
     # Filter resolved_entity_ids to include only light entities
-    light_entity_ids = [
-        entity_id for entity_id in resolved_entity_ids if entity_id.startswith("light.")
-    ]
+    light_entity_ids = [entity_id for entity_id in resolved_entity_ids if entity_id.startswith("light.")]
 
     return light_entity_ids
 
 
 def resolve_entity_ids(hass, entity_id, depth=0):
-    resolved_ids = []
     entity_reg = entity_registry.async_get(hass)
+    resolved_ids = []
 
     if not entity_id.startswith(("light", "group")):
         return resolved_ids
@@ -70,23 +57,21 @@ def resolve_entity_ids(hass, entity_id, depth=0):
         return resolved_ids
 
     if entity := hass.states.get(entity_id):
-        if not (nested_entity_ids := entity.attributes.get("entity_id", [])):
-            # It's just a plain/single light
-            return [entity_id]
+        nested_entity_ids = entity.attributes.get("entity_id", [])
 
-        # This is a grouped light
-        # we grab the config entry for this entity to determine if
-        # we should resolve the underlying entities or not.
-        if entity_reg_entry := entity_reg.async_get(entity_id):
-            if conf_entry := hass.config_entries.async_get_entry(
-                entity_reg_entry.config_entry_id
-            ):
-                if conf_entry.options.get("hide_members"):
-                    # the (group) config entry is configured to hide group members
-                    # so we do not resolve the underlying entities
-                    return [entity_id]
+        if not nested_entity_ids: # It's just a plain old light
+            resolved_ids.append(entity_id)
+        else: # It's a group possibly pretending to be a light
+            # We grab the config entry for this entity to determine if we should resolve the underlying entities
+            if entity_reg_entry := entity_reg.async_get(entity_id):
+                if conf_entry := hass.config_entries.async_get_entry(
+                    entity_reg_entry.config_entry_id
+                ):
+                    if conf_entry.options.get("hide_members", False):
+                        # The (group) config entry is configured to hide group members, so we do not resolve the underlying entities
+                        return [entity_id]
 
-        for nested_entity_id in nested_entity_ids:
-            resolved_ids.extend(resolve_entity_ids(hass, nested_entity_id, depth + 1))
+            for nested_entity_id in nested_entity_ids:
+                resolved_ids.extend(resolve_entity_ids(hass, nested_entity_id, depth + 1))
 
     return resolved_ids

--- a/custom_components/scene_presets/util.py
+++ b/custom_components/scene_presets/util.py
@@ -1,4 +1,3 @@
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
 
 
@@ -59,7 +58,7 @@ def resolve_targets(hass, entity_ids, device_ids, area_ids):
     return light_entity_ids
 
 
-def resolve_entity_ids(hass: HomeAssistant, entity_id, depth=0):
+def resolve_entity_ids(hass, entity_id, depth=0):
     resolved_ids = []
     entity_reg = entity_registry.async_get(hass)
 

--- a/custom_components/scene_presets/util.py
+++ b/custom_components/scene_presets/util.py
@@ -1,4 +1,6 @@
-from homeassistant.helpers import entity_registry, device_registry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry, entity_registry
+
 
 def ensure_list(data):
     if isinstance(data, list):
@@ -22,9 +24,15 @@ def resolve_targets(hass, entity_ids, device_ids, area_ids):
         device_entries = device_registry.async_entries_for_area(device_reg, area_id)
 
         for device_entry in device_entries:
-            registry_entries = entity_registry.async_entries_for_device(entity_reg, device_entry.id)
+            registry_entries = entity_registry.async_entries_for_device(
+                entity_reg, device_entry.id
+            )
 
-            resolved_entity_ids.extend(entry.entity_id for entry in registry_entries if entry.domain == 'light' or entry.domain == 'group')
+            resolved_entity_ids.extend(
+                entry.entity_id
+                for entry in registry_entries
+                if entry.domain == "light" or entry.domain == "group"
+            )
 
     # Then we take all entity IDs, try to figure out if they're lights, groups or groups posing as lights and resolve them down to plain lights
     for entity_id in entity_ids:
@@ -32,21 +40,28 @@ def resolve_targets(hass, entity_ids, device_ids, area_ids):
 
     # Finally, Devices can be resolved last, because they should never provide groups and thus should only ever contain plain light entities
     for device_id in device_ids:
-        registry_entries = entity_registry.async_entries_for_device(entity_reg, device_id)
+        registry_entries = entity_registry.async_entries_for_device(
+            entity_reg, device_id
+        )
 
-        resolved_entity_ids.extend(entry.entity_id for entry in registry_entries if entry.domain == 'light')
+        resolved_entity_ids.extend(
+            entry.entity_id for entry in registry_entries if entry.domain == "light"
+        )
 
     # Deduplicate entity_id list
     resolved_entity_ids = list(set(resolved_entity_ids))
 
     # Filter resolved_entity_ids to include only light entities
-    light_entity_ids = [entity_id for entity_id in resolved_entity_ids if entity_id.startswith("light.")]
+    light_entity_ids = [
+        entity_id for entity_id in resolved_entity_ids if entity_id.startswith("light.")
+    ]
 
     return light_entity_ids
 
 
-def resolve_entity_ids(hass, entity_id, depth=0):
+def resolve_entity_ids(hass: HomeAssistant, entity_id, depth=0):
     resolved_ids = []
+    entity_reg = entity_registry.async_get(hass)
 
     if not entity_id.startswith(("light", "group")):
         return resolved_ids
@@ -56,12 +71,23 @@ def resolve_entity_ids(hass, entity_id, depth=0):
         return resolved_ids
 
     if entity := hass.states.get(entity_id):
-        nested_entity_ids = entity.attributes.get("entity_id", [])
+        if not (nested_entity_ids := entity.attributes.get("entity_id", [])):
+            # It's just a plain/single light
+            return [entity_id]
 
-        if not nested_entity_ids: # It's just a plain old light
-            resolved_ids.append(entity_id)
-        else: # It's a group possibly pretending to be a light
-            for nested_entity_id in nested_entity_ids:
-                resolved_ids.extend(resolve_entity_ids(hass, nested_entity_id, depth + 1))
+        # This is a grouped light
+        # we grab the config entry for this entity to determine if
+        # we should resolve the underlying entities or not.
+        if entity_reg_entry := entity_reg.async_get(entity_id):
+            if conf_entry := hass.config_entries.async_get_entry(
+                entity_reg_entry.config_entry_id
+            ):
+                if conf_entry.options.get("hide_members"):
+                    # the (group) config entry is configured to hide group members
+                    # so we do not resolve the underlying entities
+                    return [entity_id]
+
+        for nested_entity_id in nested_entity_ids:
+            resolved_ids.extend(resolve_entity_ids(hass, nested_entity_id, depth + 1))
 
     return resolved_ids


### PR DESCRIPTION
Closes #16 

Basically this will check if the "hide group members" option is enabled for a grouped light.
If so, it will not unwrap the group's childs.